### PR TITLE
Add unit tests for core utilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "tsc lib/datediff.ts lib/formatNumber.ts lib/filter-keys.ts lib/parse-json.ts --outDir dist/lib --module commonjs && node --test"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.8.0",

--- a/tests/datediff.test.js
+++ b/tests/datediff.test.js
@@ -1,0 +1,15 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { datediff } = require('../dist/lib/datediff.js');
+
+test('calculates difference in days', () => {
+  const first = new Date(2023, 0, 1);
+  const second = new Date(2023, 0, 2);
+  assert.equal(datediff(first, second), 1);
+});
+
+test('returns 0 for same dates', () => {
+  const first = new Date(2023, 0, 1);
+  const second = new Date(2023, 0, 1);
+  assert.equal(datediff(first, second), 0);
+});

--- a/tests/filter-keys.test.js
+++ b/tests/filter-keys.test.js
@@ -1,0 +1,9 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { filterKeys } = require('../dist/lib/filter-keys.js');
+
+test('filters object keys', () => {
+  const data = { a: 1, b: 2, c: 3 };
+  const result = filterKeys(data, ['a', 'c']);
+  assert.deepEqual(result, { a: 1, c: 3 });
+});

--- a/tests/formatNumber.test.js
+++ b/tests/formatNumber.test.js
@@ -1,0 +1,15 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { formatNumber } = require('../dist/lib/formatNumber.js');
+
+test('formats number with locale and digits', () => {
+  assert.equal(formatNumber(1234.5, 1), '1\u00a0234,5');
+});
+
+test('returns 0 when number is 0', () => {
+  assert.equal(formatNumber(0), 0);
+});
+
+test('returns undefined for undefined input', () => {
+  assert.equal(formatNumber(undefined), undefined);
+});

--- a/tests/parse-json.test.js
+++ b/tests/parse-json.test.js
@@ -1,0 +1,15 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { parseJSON } = require('../dist/lib/parse-json.js');
+
+test('uses json method when available', async () => {
+  const resp = { json: async () => ({ a: 1 }) };
+  const result = await parseJSON(resp);
+  assert.deepEqual(result, { a: 1 });
+});
+
+test('returns object when json method missing', () => {
+  const resp = { a: 1 };
+  const result = parseJSON(resp);
+  assert.equal(result, resp);
+});


### PR DESCRIPTION
## Summary
- add `npm test` script using TypeScript compiler and Node's test runner
- cover date difference, number formatting, key filtering, and JSON parsing utilities with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b6e34392548325923651fa00bda88d